### PR TITLE
fix: fallback for crypto.randomUUID on non-HTTPS connections

### DIFF
--- a/components/dossier/left-sidebar.tsx
+++ b/components/dossier/left-sidebar.tsx
@@ -331,7 +331,8 @@ export function LeftSidebar({ isCollapsed, onToggle, project, projectId, width, 
 
   const addMessage = (role: 'user' | 'agent', content: string) => {
     if (!content?.trim()) return;
-    setMessages(prev => [...prev, { id: crypto.randomUUID(), role, content }]);
+    const id = crypto.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    setMessages(prev => [...prev, { id, role, content }]);
   };
 
   const lastRefetchRef = useRef<number>(0);


### PR DESCRIPTION
Fixes #7

## Summary

- `crypto.randomUUID()` requires a [secure context](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID) (HTTPS or localhost) and throws when the app is accessed over plain HTTP on a LAN
- Adds a fallback (`Date.now` + `Math.random`) for the chat message ID in `left-sidebar.tsx`, which only serves as a React list key
- All other `crypto.randomUUID()` calls are server-side (Node.js) and unaffected

## Notes

This might be a blunt fallback, and either one would expect to run on https or delegate key-generation to an isolated function. So no hard feelings if rejecting. Just sharing my path to victory 😸 


## Test plan

- [ ] Access Dossier over HTTP on a LAN (e.g. `http://192.168.x.x:3000`)
- [ ] Send a chat message — verify it renders without errors
- [ ] Verify HTTPS/localhost still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)