### PR TITLE
chore(deps): ignore pnpm/action-setup v6+ in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # pnpm/action-setup v6 ignores the explicit `version: 10` input and
+      # bootstraps pnpm v11, breaking `pnpm install --frozen-lockfile`
+      # (pnpm/action-setup#225, #227). Stay on v5 until resolved.
+      - dependency-name: "pnpm/action-setup"
+        versions: [">=6"]


### PR DESCRIPTION
## Summary
Follow-up to #43 (which standardized our CI action versions). Adds a dependabot ignore so it stops re-raising the `pnpm/action-setup` v6 bump (#32).

`pnpm/action-setup@v6` ignores the explicit `version: 10` input and bootstraps pnpm **v11**, which breaks `pnpm install --frozen-lockfile` (pnpm/action-setup#225, #227). Our workflows pin `version: 10` with no `packageManager` field, so we deliberately stay on **v5** until that's resolved.

This commit didn't make it into #43 (it was squash-merged a moment before the follow-up commit landed), hence this small standalone PR.

## Test plan
- [x] YAML is valid (single `ignore` block under the existing `github-actions` ecosystem)
- [ ] Dependabot honors the ignore on its next weekly run (no new pnpm/action-setup v6 PR)

Made with [Cursor](https://cursor.com)